### PR TITLE
Fixed logs output for velero pods

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -16,4 +16,6 @@ done
 # Collect the migration and velero CRs
 /usr/bin/gather_crs
 
+# Collect the logs
+/usr/bin/gather_logs
 exit 0

--- a/collection-scripts/gather_logs
+++ b/collection-scripts/gather_logs
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+for ns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --all-namespaces --no-headers | awk '{print $1}')
+do
+  for pod in $(/usr/bin/oc get pods --no-headers --namespace $ns | awk '{print $1}')
+  do
+    object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+    mkdir -p ${object_collection_path}
+    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} > "${object_collection_path}/current.log"
+    /usr/bin/oc logs --previous --all-containers --namespace ${ns} ${pod} > "${object_collection_path}/previous.log"
+  done
+done


### PR DESCRIPTION
```bash
must-gather.local.8620869833145430561/quay-io-dgrigore-must-gather-sha256-f6de6857948fb7d9fcafc19c3dc30bb50be8b313af3e063682b88b9076c2a543/namespaces/openshift-migration/logs/
├── migration-operator-69d89cfd4f-vv2sl
│   ├── current.log
│   └── previous.log
├── registry-99bab510-7e22-11ea-a5c9-02d228285a28-skt7q-1-deploy
│   ├── current.log
│   └── previous.log
├── registry-99bab510-7e22-11ea-a5c9-02d228285a28-skt7q-1-rxdwd
│   ├── current.log
│   └── previous.log
├── restic-2kjnk
│   ├── current.log
│   └── previous.log
├── restic-clpxc
│   ├── current.log
│   └── previous.log
├── restic-gzcwd
│   ├── current.log
│   └── previous.log
└── velero-6dd4ff7845-z9dzh
    ├── current.log
    └── previous.log
```