### PR TITLE
Add Prometheus metrics dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ prometheus-run: prometheus-cleanup-container prometheus-load-dump
 	  prom/prometheus:v2.6.0 \
 	&& echo "Started Prometheus on http://localhost:9090"
 
-prometheus-load-dump: prometheus-cleanup-data
+prometheus-load-dump: prometheus-check-archive-file prometheus-cleanup-data
 	mkdir -p ${PROMETHEUS_LOCAL_DATA_DIR}
 	tar xvf ${PROMETHEUS_DUMP_PATH} -C ${PROMETHEUS_LOCAL_DATA_DIR} --strip-components=1 --no-same-owner
 	chmod 777 -R ${PROMETHEUS_LOCAL_DATA_DIR}
@@ -38,3 +38,6 @@ prometheus-cleanup-data:
 	rm -rf ${PROMETHEUS_LOCAL_DATA_DIR}
 
 prometheus-cleanup: prometheus-cleanup-container prometheus-cleanup-data
+
+prometheus-check-archive-file:
+	test -f "${PROMETHEUS_DUMP_PATH}" || (echo "Error: Prometheus archive file does not exist. Specify valid file in PROMETHEUS_DUMP_PATH environment variable."; exit 1)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ IMAGE_REGISTRY ?= quay.io
 IMAGE_TAG ?= latest
 IMAGE_NAME ?= konveyor/must-gather
 
+PROMETHEUS_LOCAL_DATA_DIR ?= /tmp/mig-prometheus-data-dump
+# Search for prom_data.tar.gz archive in must-gather output in currect directory by default
+PROMETHEUS_DUMP_PATH ?= $(shell find ./must-gather.local* -name prom_data.tar.gz -printf "%T@ %p\n" | sort -n | tail -1 | cut -d" " -f2)
+
 build: docker-build docker-push
 
 docker-build:
@@ -11,3 +15,26 @@ docker-push:
 	docker push ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG}
 
 .PHONY: build docker-build docker-push
+
+prometheus-run: prometheus-cleanup-container prometheus-load-dump
+	docker run -d \
+	  --mount type=bind,source=${PROMETHEUS_LOCAL_DATA_DIR},target=/etc/prometheus/data \
+	  --name mig-metrics-prometheus \
+	  --publish 127.0.0.1:9090:9090 \
+	  prom/prometheus:v2.6.0 \
+	&& echo "Started Prometheus on http://localhost:9090"
+
+prometheus-load-dump: prometheus-cleanup-data
+	mkdir -p ${PROMETHEUS_LOCAL_DATA_DIR}
+	tar xvf ${PROMETHEUS_DUMP_PATH} -C ${PROMETHEUS_LOCAL_DATA_DIR} --strip-components=1 --no-same-owner
+	chmod 777 -R ${PROMETHEUS_LOCAL_DATA_DIR}
+
+prometheus-cleanup-container:
+	# delete data files directly from the container to allow delete data directory from outside of the container
+	docker exec mig-metrics-prometheus rm -rf /prometheus || true
+	docker rm -f mig-metrics-prometheus || true
+
+prometheus-cleanup-data:
+	rm -rf ${PROMETHEUS_LOCAL_DATA_DIR}
+
+prometheus-cleanup: prometheus-cleanup-container prometheus-cleanup-data

--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ The command above will create a local directory with a dump of the CAM state.
 You will get a dump of:
 - All namespaces where a CAM toolset is installed, including pod logs
 - All velero.io and migration.openshift.io resources located in those namespaces
+- Prometheus metrics
 
+#### Preview metrics on local Prometheus server
+
+Get Prometheus metrics data directory dump (last day, might take a while):
+```sh
+oc adm must-gather --image quay.io/konveyor/must-gather:latest -- /usr/bin/gather_metrics_dump
+```
+
+Run local Prometheus instance with dumped data:
+```sh
+make prometheus-run # and prometheus-cleanup when you're done
+```
+The latest Prometheus data file (prom_data.tar.gz) in current directory/subdirectories is searched by default. Could be specified in ```PROMETHEUS_DUMP_PATH``` environment variable.
 
 ### Development
 You can build the image locally using the Dockerfile included.

--- a/collection-scripts/_metrics_chart_template_part_1.html
+++ b/collection-scripts/_metrics_chart_template_part_1.html
@@ -1,0 +1,69 @@
+
+<!doctype html>
+<html>
+<head>
+	<title>Prometheus Metrics Charts</title>
+	<!-- ChartJS library -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.bundle.min.js"></script>
+	<!-- Coloring plugin -->
+	<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"></script>
+	<style>
+		body {
+			padding: 1ex 3em 1ex 3em;
+			text-align: center;
+			color: #555;
+		}
+		canvas {
+			margin-bottom: 10ex;
+		}
+	</style>
+</head>
+
+<body>
+	<h1>Prometheus Metrics Charts</h1>
+	<div id="charts">
+	</div>
+
+    <script>
+		window.charts = [];
+
+  		window.onload = function() {
+  			// Dynamically create charts for provided metrics
+  			for (var i = 0; i < window.dataset.length; i++) {
+
+  				// Prepare dataset and config
+  				var chartConfig = {
+		  			type: 'line',
+		  			data: {
+		  				datasets: [window.dataset[i]],
+		  			},
+		  			options: {
+		  				responsive: true,
+		  				scales: {
+		  					xAxes: [{
+		  						type: 'time',
+		  						display: true,
+		  					}],
+						  },
+						plugins: {
+            				colorschemes: {
+                				scheme: 'brewer.Paired12'
+							},
+        				}
+		  			}
+		  		};
+  
+  				// Prepare HTML context
+  				var chartContainer = document.createElement("div");
+  				var canvas = document.createElement("canvas");
+				chartContainer.appendChild(canvas);
+				document.querySelector("div#charts").appendChild(chartContainer);
+  				var ctx = canvas.getContext('2d');
+  
+  				// Draw the chart
+  				window.charts.push(new Chart(ctx, chartConfig));
+			}
+		};
+
+		// Browsers/CORS blocks loading local files, embeding all chart data directly into the HTML file
+		window.dataset = prepareDataset('

--- a/collection-scripts/_metrics_chart_template_part_1.html
+++ b/collection-scripts/_metrics_chart_template_part_1.html
@@ -2,11 +2,14 @@
 <!doctype html>
 <html>
 <head>
-	<title>Prometheus Metrics Charts</title>
+	<title>Metrics Chart</title>
 	<!-- ChartJS library -->
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.bundle.min.js"></script>
 	<!-- Coloring plugin -->
 	<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-colorschemes"></script>
+	<!-- Zooming plugin -->
+	<script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+	<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@0.7.7"></script>
 	<style>
 		body {
 			padding: 1ex 3em 1ex 3em;
@@ -16,53 +19,66 @@
 		canvas {
 			margin-bottom: 10ex;
 		}
+		div#chart-controls > button {
+			display: none;
+		}
 	</style>
 </head>
 
 <body>
-	<h1>Prometheus Metrics Charts</h1>
-	<div id="charts">
+	<h1>Metrics Chart</h1>
+	<div id="chart">
+	</div>
+	<div id="chart-controls">
+		<button id="zoom-btn" onclick='window.chart.resetZoom(); document.querySelector("#zoom-btn").style.display = "none";'>Reset Zoom</button>
 	</div>
 
     <script>
-		window.charts = [];
+		window.chart = null;
+		window.onload = function() {
+			// Prepare dataset and config
+			var chartConfig = {
+				type: 'line',
+				data: {
+					datasets: window.dataset,
+				},
+				options: {
+					responsive: true,
+					scales: {
+						xAxes: [{
+							type: 'time',
+							display: true,
+						}],
+					},
+					hover: {
+						mode: "dataset"
+					},
+					plugins: {
+						colorschemes: {
+							scheme: 'tableau.Tableau10'
+						},
+						zoom: {
+							zoom: {
+								enabled: true,
+								drag: false,
+								mode: 'x',
+								speed: 0.2,
+								onZoomComplete: function({chart}) { document.querySelector("#zoom-btn").style.display = "block"; }
+							}
+						}
+					}
+				}
+			};
 
-  		window.onload = function() {
-  			// Dynamically create charts for provided metrics
-  			for (var i = 0; i < window.dataset.length; i++) {
+			// Prepare HTML context
+			var chartContainer = document.createElement("div");
+			var canvas = document.createElement("canvas");
+			chartContainer.appendChild(canvas);
+			document.querySelector("div#chart").appendChild(chartContainer);
+			var ctx = canvas.getContext('2d');
 
-  				// Prepare dataset and config
-  				var chartConfig = {
-		  			type: 'line',
-		  			data: {
-		  				datasets: [window.dataset[i]],
-		  			},
-		  			options: {
-		  				responsive: true,
-		  				scales: {
-		  					xAxes: [{
-		  						type: 'time',
-		  						display: true,
-		  					}],
-						  },
-						plugins: {
-            				colorschemes: {
-                				scheme: 'brewer.Paired12'
-							},
-        				}
-		  			}
-		  		};
-  
-  				// Prepare HTML context
-  				var chartContainer = document.createElement("div");
-  				var canvas = document.createElement("canvas");
-				chartContainer.appendChild(canvas);
-				document.querySelector("div#charts").appendChild(chartContainer);
-  				var ctx = canvas.getContext('2d');
-  
-  				// Draw the chart
-  				window.charts.push(new Chart(ctx, chartConfig));
-			}
+			// Draw the chart
+			window.chart = new Chart(ctx, chartConfig);
 		};
 
 		// Browsers/CORS blocks loading local files, embeding all chart data directly into the HTML file

--- a/collection-scripts/_metrics_chart_template_part_1.html
+++ b/collection-scripts/_metrics_chart_template_part_1.html
@@ -12,7 +12,7 @@
 	<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@0.7.7"></script>
 	<style>
 		body {
-			padding: 1ex 3em 1ex 3em;
+			padding: 1ex 5em 1ex 5em;
 			text-align: center;
 			color: #555;
 		}
@@ -43,7 +43,11 @@
 					datasets: window.dataset,
 				},
 				options: {
+					animation: {
+						duration: 0
+					},
 					responsive: true,
+					responsiveAnimationDuration: 0,
 					scales: {
 						xAxes: [{
 							type: 'time',
@@ -51,7 +55,16 @@
 						}],
 					},
 					hover: {
+						animationDuration: 0,
 						mode: "dataset"
+					},
+					tooltips: {
+						callbacks: {
+							label: (tooltipItem, data) => {
+								var label = data.datasets[tooltipItem.datasetIndex].label;
+								return label.split("\n");
+							}
+						}
 					},
 					plugins: {
 						colorschemes: {

--- a/collection-scripts/_metrics_chart_template_part_2.html
+++ b/collection-scripts/_metrics_chart_template_part_2.html
@@ -13,12 +13,14 @@
 				var dataline = {
 					pointRadius: 0,
 					fill: false,
-					lineTension: 0,
+					borderWidth: 2,
 				};
 				var metric = data[i].metric;
 				dataline.label = metric.instance + " " + metric.__name__
 				if (metric.type) dataline.label += " " + metric.type
 				if (metric.status) dataline.label += " " + metric.status
+				// Append additional metric identifiers similar to ^
+
 				dataline.data = data[i].values.map(parseSample);
 				dataset.push(dataline);
 			}

--- a/collection-scripts/_metrics_chart_template_part_2.html
+++ b/collection-scripts/_metrics_chart_template_part_2.html
@@ -1,0 +1,29 @@
+');
+
+		// Parse a metric sample to ChartJS-friendly format
+		function parseSample(promSample) {
+			return {x: new Date(parseInt(promSample[0]) * 1000), y: parseFloat(promSample[1])}
+		}
+
+		// Parse Prometheus query_range JSON output to be processed by chart library
+		function prepareDataset(queryResp) {
+			var dataset = []
+			data = JSON.parse(queryResp).data.result;
+			for (var i = 0; i < data.length; i++) {
+				var dataline = {
+					pointRadius: 0,
+					fill: false,
+					lineTension: 0,
+				};
+				var metric = data[i].metric;
+				dataline.label = metric.instance + " " + metric.__name__
+				if (metric.type) dataline.label += " " + metric.type
+				if (metric.status) dataline.label += " " + metric.status
+				dataline.data = data[i].values.map(parseSample);
+				dataset.push(dataline);
+			}
+			return dataset;
+		}
+	</script>
+</body>
+</html>

--- a/collection-scripts/_metrics_chart_template_part_2.html
+++ b/collection-scripts/_metrics_chart_template_part_2.html
@@ -14,12 +14,13 @@
 					pointRadius: 0,
 					fill: false,
 					borderWidth: 2,
+					tension: 0,
 				};
 				var metric = data[i].metric;
-				dataline.label = metric.instance + " " + metric.__name__
-				if (metric.type) dataline.label += " " + metric.type
-				if (metric.status) dataline.label += " " + metric.status
-				// Append additional metric identifiers similar to ^
+				dataline.label = metric.instance + " \n" + metric.__name__
+				if (metric.type) dataline.label += " \n" + metric.type
+				if (metric.status) dataline.label += " \n" + metric.status
+				// Append additional metric identifiers similar to ^ if needed
 
 				dataline.data = data[i].values.map(parseSample);
 				dataset.push(dataline);

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -44,5 +44,8 @@ for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --a
 
   # Collect the logs
   /usr/bin/gather_logs
+
+  # Collect metrics from Prometheus
+  /usr/bin/gather_metrics
 done
 exit 0

--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -19,10 +19,14 @@ oc exec -n openshift-monitoring prometheus-k8s-0 -- \
   curl -G http://localhost:9090/api/v1/targets/metadata --data match_target%3D%7Binstance!%3D%22%22%7D \
   > "${object_collection_path}/prometheus_target_metadata.json"
 
-# Prometheus - filtered metrics json using query_range
+# Prometheus - filtered metrics json using query_range and HTML files with charts
 for metric_name in node_load1 cam_app_workload_migrations mtc_client
 do
-  oc exec -n openshift-monitoring prometheus-k8s-0 -- \
-    curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_day_ago}&end=${time_now}&step=14" \
-    > "${object_collection_path}/prometheus_queries/${metric_name}.json"
+  data=`oc exec -n openshift-monitoring prometheus-k8s-0 -- curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_day_ago}&end=${time_now}&step=14"`
+  # JSON data
+  echo $data > "${object_collection_path}/prometheus_queries/${metric_name}.json"
+  # HTML file with the chart (using concatenated write to file, an elegant string replacement/variable evaluation didn't work with 100s kBs data)
+  cat /usr/bin/_metrics_chart_template_part_1.html > "${object_collection_path}/prometheus_queries/${metric_name}.html"
+  echo "${data}\\" >> "${object_collection_path}/prometheus_queries/${metric_name}.html"
+  cat /usr/bin/_metrics_chart_template_part_2.html >> "${object_collection_path}/prometheus_queries/${metric_name}.html"
 done

--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Prepare gather setup
+unset KUBECONFIG
+object_collection_path="/must-gather/metrics"
+mkdir ${object_collection_path}
+mkdir "${object_collection_path}/prometheus_queries"
+
+# Setup vars
+time_now=$(date +%s)
+time_day_ago=$(($time_now - 24*60*60))
+
+# OpenShift monitoring namespace status
+oc get all -n openshift-monitoring > "${object_collection_path}/openshift_monitoring_status"
+
+# Prometheus - metadata json dump
+echo "Dumping Prometheus metadata ..."
+oc exec -n openshift-monitoring prometheus-k8s-0 -- \
+  curl -G http://localhost:9090/api/v1/targets/metadata --data match_target%3D%7Binstance!%3D%22%22%7D \
+  > "${object_collection_path}/prometheus_target_metadata.json"
+
+# Prometheus - filtered metrics json using query_range
+for metric_name in node_load1 cam_app_workload_migrations mtc_client
+do
+  oc exec -n openshift-monitoring prometheus-k8s-0 -- \
+    curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_day_ago}&end=${time_now}&step=14" \
+    > "${object_collection_path}/prometheus_queries/${metric_name}.json"
+done

--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -8,7 +8,7 @@ mkdir "${object_collection_path}/prometheus_queries"
 
 # Setup vars
 time_now=$(date +%s)
-time_day_ago=$(($time_now - 24*60*60))
+time_ago=$(($time_now - 6*60*60))
 
 # OpenShift monitoring namespace status
 oc get all -n openshift-monitoring > "${object_collection_path}/openshift_monitoring_status"
@@ -22,7 +22,7 @@ oc exec -n openshift-monitoring prometheus-k8s-0 -- \
 # Prometheus - filtered metrics json using query_range and HTML files with charts
 for metric_name in node_load1 cam_app_workload_migrations mtc_client
 do
-  data=`oc exec -n openshift-monitoring prometheus-k8s-0 -- curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_day_ago}&end=${time_now}&step=14"`
+  data=`oc exec -n openshift-monitoring prometheus-k8s-0 -- curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_ago}&end=${time_now}&step=14"`
   # JSON data
   echo $data > "${object_collection_path}/prometheus_queries/${metric_name}.json"
   # HTML file with the chart (using concatenated write to file, an elegant string replacement/variable evaluation didn't work with 100s kBs data)

--- a/collection-scripts/gather_metrics_dump
+++ b/collection-scripts/gather_metrics_dump
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# NOTICE: THIS FILE IS NOT INCLUDED IN THE DEFAULT GATHER SCRIPT
+#
+# Can be executed by: oc adm must-gather --image quay.io/konveyor/must-gather:latest -- /usr/bin/gather_metrics_dump
+#
+
+# Prepare gather setup
+unset KUBECONFIG
+object_collection_path="/must-gather/metrics"
+mkdir ${object_collection_path}
+
+# Setup vars
+time_now=$(date +%s)
+time_day_ago=$(($time_now - 24*60*60))
+
+# Prometheus - last day data files dump
+echo "Running Prometheus data files last day dump ... (might take a while)"
+oc exec -n openshift-monitoring prometheus-k8s-0 -- \
+  bash -c "find /prometheus -newermt \"$(date '+%Y-%m-%d %H:%M' -d @${time_day_ago})\" | tar cvzf - --no-recursion --exclude \"queries.active\" --files-from -" \
+  > "${object_collection_path}/prom_data.tar.gz"
+
+# oc exec and tar could be unhappy with file changes during its compression, however if the dump archive was created, it is success
+if [ -f "${object_collection_path}/prom_data.tar.gz" ]; then
+  exit 0
+else
+  exit $?
+fi


### PR DESCRIPTION
Adding optional Prometheus metrics data file dump for last day to get all metrics files locally and extending Makefile to work with the Prometheus data and run it locally.

Command for Prometheus last day data dump testing:
```
oc adm must-gather --image quay.io/maufart/must-gather:latest -- /usr/bin/gather_metrics_dump
```

Also adding Prometheus data dump (using query_range into json for cam_app_workload_migrations and mtc_client metrics) which is included in each must-gather output, so far without visualisation.

Related to https://github.com/konveyor/must-gather/issues/4