### PR TITLE
Update metrics gather to not store data in bash variables

### DIFF
--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -16,16 +16,17 @@ oc get all -n openshift-monitoring > "${object_collection_path}/openshift_monito
 # Prometheus - metadata json dump
 echo "Dumping Prometheus metadata ..."
 oc exec -n openshift-monitoring prometheus-k8s-0 -- \
-  curl -G http://localhost:9090/api/v1/targets/metadata --data match_target%3D%7Binstance!%3D%22%22%7D \
+  curl -G http://localhost:9090/api/v1/targets/metadata -s --data match_target%3D%7Binstance!%3D%22%22%7D \
   > "${object_collection_path}/prometheus_target_metadata.json"
 
 # Prometheus - filtered metrics json using query_range and HTML files with charts
 for metric_name in node_load1 cam_app_workload_migrations mtc_client
 do
-  # JSON data
-  oc exec -n openshift-monitoring prometheus-k8s-0 -- curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_ago}&end=${time_now}&step=14" \
-    > "${object_collection_path}/prometheus_queries/${metric_name}.json" \
+  oc exec -n openshift-monitoring prometheus-k8s-0 -- curl -s "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_ago}&end=${time_now}&step=14" \
     > dump.json
+
+  # JSON data
+  cat dump.json > "${object_collection_path}/prometheus_queries/${metric_name}.json"
 
   # HTML file with the chart (using concatenated write to file, an elegant string replacement/variable evaluation didn't work with 100s kBs data)
   cat /usr/bin/_metrics_chart_template_part_1.html > "${object_collection_path}/prometheus_queries/${metric_name}.html"
@@ -33,5 +34,5 @@ do
   cat /usr/bin/_metrics_chart_template_part_2.html >> "${object_collection_path}/prometheus_queries/${metric_name}.html"
 
   # Cleanup the temp file
-  rm dump.json
+  rm -f dump.json
 done

--- a/collection-scripts/gather_metrics
+++ b/collection-scripts/gather_metrics
@@ -22,11 +22,16 @@ oc exec -n openshift-monitoring prometheus-k8s-0 -- \
 # Prometheus - filtered metrics json using query_range and HTML files with charts
 for metric_name in node_load1 cam_app_workload_migrations mtc_client
 do
-  data=`oc exec -n openshift-monitoring prometheus-k8s-0 -- curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_ago}&end=${time_now}&step=14"`
   # JSON data
-  echo $data > "${object_collection_path}/prometheus_queries/${metric_name}.json"
+  oc exec -n openshift-monitoring prometheus-k8s-0 -- curl "http://localhost:9090/api/v1/query_range?query=${metric_name}&start=${time_ago}&end=${time_now}&step=14" \
+    > "${object_collection_path}/prometheus_queries/${metric_name}.json" \
+    > dump.json
+
   # HTML file with the chart (using concatenated write to file, an elegant string replacement/variable evaluation didn't work with 100s kBs data)
   cat /usr/bin/_metrics_chart_template_part_1.html > "${object_collection_path}/prometheus_queries/${metric_name}.html"
-  echo "${data}\\" >> "${object_collection_path}/prometheus_queries/${metric_name}.html"
+  cat dump.json >> "${object_collection_path}/prometheus_queries/${metric_name}.html"
   cat /usr/bin/_metrics_chart_template_part_2.html >> "${object_collection_path}/prometheus_queries/${metric_name}.html"
+
+  # Cleanup the temp file
+  rm dump.json
 done


### PR DESCRIPTION
HTML preview generation used variables with data gathered from Openshift Prometheus service. That could break oc adm must-gather command when turned on debugging output (set +x).

Updating the metrics query gather code to use temp dump.json file instead of storing data in bach variable.
