### PR TITLE
Bug 1898522/1897501: Update Makefile to launch prom v2.21.0 to match OCP 4.6, fix wal mount dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-push:
 
 prometheus-run: prometheus-cleanup-container prometheus-load-dump
 	docker run -d \
-	  --mount type=bind,source=${PROMETHEUS_LOCAL_DATA_DIR},target=/etc/prometheus/data \
+	  --mount type=bind,source=${PROMETHEUS_LOCAL_DATA_DIR},target=/prometheus \
 	  --name mig-metrics-prometheus \
 	  --publish 127.0.0.1:9090:9090 \
 	  prom/prometheus:v2.21.0 \
@@ -27,7 +27,7 @@ prometheus-run: prometheus-cleanup-container prometheus-load-dump
 prometheus-load-dump: prometheus-check-archive-file prometheus-cleanup-data
 	mkdir -p ${PROMETHEUS_LOCAL_DATA_DIR}
 	tar xvf ${PROMETHEUS_DUMP_PATH} -C ${PROMETHEUS_LOCAL_DATA_DIR} --strip-components=1 --no-same-owner
-	chmod 777 -R ${PROMETHEUS_LOCAL_DATA_DIR}
+	chmod -R 777 ${PROMETHEUS_LOCAL_DATA_DIR}
 
 prometheus-cleanup-container:
 	# delete data files directly from the container to allow delete data directory from outside of the container

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ prometheus-run: prometheus-cleanup-container prometheus-load-dump
 	  --mount type=bind,source=${PROMETHEUS_LOCAL_DATA_DIR},target=/etc/prometheus/data \
 	  --name mig-metrics-prometheus \
 	  --publish 127.0.0.1:9090:9090 \
-	  prom/prometheus:v2.6.0 \
+	  prom/prometheus:v2.21.0 \
 	&& echo "Started Prometheus on http://localhost:9090"
 
 prometheus-load-dump: prometheus-check-archive-file prometheus-cleanup-data


### PR DESCRIPTION
I doubt there is any one Prometheus version that will be compatible with the full range of OCP 4.x clusters, but this seems to allow us to view Prometheus data from an OCP 4.6 cluster without encountering:

```
level=error ts=2020-11-17T11:48:11.975720503Z caller=main.go:624 err="opening storage failed: read WAL: backfill checkpoint: read records: corruption in segment data/wal/checkpoint.00000001/00000000 at 1231: unexpected record type 9"
```

I also had to fix the target mount point in the container to reflect what prometheus expects in the v2.21.0 image.

https://bugzilla.redhat.com/show_bug.cgi?id=1898522
https://bugzilla.redhat.com/show_bug.cgi?id=1897501