### PR TITLE
Add "gather_migrated_namespaces" script, gather PVs, StorageClasses (cluster-scoped), Routes, Service (just registry namespaces)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM quay.io/openshift/origin-must-gather:4.5 as builder
 FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
-RUN microdnf -y install rsync tar gzip graphviz findutils
+RUN microdnf -y install rsync tar gzip graphviz findutils jq
 
 COPY --from=gobuilder /opt/app-root/src/go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM quay.io/openshift/origin-must-gather:4.5 as builder
 FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
-RUN microdnf -y install rsync tar gzip graphviz findutils jq
+RUN microdnf -y install rsync tar gzip graphviz findutils jq grep
 
 COPY --from=gobuilder /opt/app-root/src/go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ The command above will create a local directory with a dump of the MTC state.
 
 You will get a dump of:
 - All namespaces where a MTC toolset is installed, including pod logs
-- All velero.io and migration.openshift.io resources located in those namespaces
+- All velero.io and migration.openshift.io resources located in MTC namespaces
+- StorageClasses and PersistentVolume YAML
+- Routes and Service YAML from the `default` and `openshift-image-registry` namespaces
 - Prometheus metrics
 
 **Essential-only gather**
@@ -25,6 +27,15 @@ Differences from full gather:
 ```
 # Essential gather (available time windows: [1h, 6h, 24h, 72h, all])
 oc adm must-gather --image=quay.io/konveyor/must-gather:latest -- /usr/bin/gather_24h_essential
+```
+
+**Migrated namespace gather**
+
+Troubleshooting a migration often requires looking at resource YAML in migrated namespaces. 
+You can easily gather the content of the namespaces from the most recent migration attempt with this command.
+```
+# Gathers content of namespaces migrated during latest MigMigration
+oc adm must-gather --image=quay.io/djwhatle/must-gather:latest -- /usr/bin/gather_migrated_namespaces
 ```
 
 #### Preview metrics on local Prometheus server

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ The command above will create a local directory with a dump of the MTC state.
 You will get a dump of:
 - All namespaces where a MTC toolset is installed, including pod logs
 - All velero.io and migration.openshift.io resources located in MTC namespaces
-- StorageClasses and PersistentVolume YAML
-- Routes and Service YAML from the `default` and `openshift-image-registry` namespaces
+- StorageClasse and PersistentVolume resources
+- Route and Service resources from the `default` and `openshift-image-registry` namespaces
 - Prometheus metrics
 
 **Essential-only gather**
@@ -24,7 +24,7 @@ You will get a dump of:
 Differences from full gather:
  - Logs are only gathered from specified time window
  - Skips collection of prometheus metrics, pprof. Removes duplicate logs from payload.
-```
+```sh
 # Essential gather (available time windows: [1h, 6h, 24h, 72h, all])
 oc adm must-gather --image=quay.io/konveyor/must-gather:latest -- /usr/bin/gather_24h_essential
 ```
@@ -33,7 +33,7 @@ oc adm must-gather --image=quay.io/konveyor/must-gather:latest -- /usr/bin/gathe
 
 Troubleshooting a migration often requires looking at resource YAML in migrated namespaces. 
 You can easily gather the content of the namespaces from the most recent migration attempt with this command.
-```
+```sh
 # Gathers content of namespaces migrated during latest MigMigration
 oc adm must-gather --image=quay.io/djwhatle/must-gather:latest -- /usr/bin/gather_migrated_namespaces
 ```

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -16,13 +16,6 @@ for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --a
   done
   echo "Will collect debug info from migclusters [${clusters[@]}]"
 
-  # Find the latest migration, plan, and associated namespaces so we can gather additional info from those
-  set -x
-  latest_migration=$(oc -n ${localns} get migmigration -o json | jq -r '.items|=sort_by(.metadata.creationTimestamp)' | jq -r '.items[-1].metadata.name')
-  latest_migration_plan=$(oc -n ${localns} get migmigration ${latest_migration} -o jsonpath={.spec.migPlanRef.name})
-  latest_migration_namespaces=$(oc -n ${localns} get migplan ${latest_migration_plan} -o json | jq -r '.spec.namespaces[]')
-  latest_migration_clusters=$(oc -n ${localns} get migplan ${latest_migration_plan} -o json | jq -r '.spec.destMigClusterRef.name, .spec.srcMigClusterRef.name')
-
   # Iterate over all connected non-host OpenShift clusters
   for cluster in ${clusters[@]}; do
     unset KUBECONFIG
@@ -47,19 +40,6 @@ for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --a
       echo "[cluster=${cluster}][namespace=${ns}] Detected MTC installation"
       namespaces+=(${ns})
     done
-
-    # Check if this cluster has a migrated namespace we want to oc adm inspect
-    if echo $latest_migration_clusters | grep -o "\b${cluster}\b" > /dev/null; then
-      echo "[cluster=${cluster}] FOUND within latest_migration_clusters=${latest_migration_clusters}"
-      for ns in ${latest_migration_namespaces}; do
-        echo "[cluster=${cluster}][namespace=${ns}][migration=${latest_migration}][plan=${latest_migration_plan}] Running oc adm inspect on namespace that is part of latest migration and plan"
-        mkdir -p must-gather/clusters/${cluster}/migrated-namespaces
-        /usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster}/migrated-namespaces ns/${ns} &
-      done
-    else
-      echo "[cluster=${cluster}] NOT FOUND within latest_migration_clusters=${latest_migration_clusters}"
-    fi
-
 
     # Collect all resources in MTC namespaces with must-gather
     for ns in ${namespaces[@]}; do

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -47,6 +47,16 @@ for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --a
       /usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster} --all-namespaces ns/${ns} &
     done
 
+    # Collect PV and StorageClass info for cluster
+    echo "[cluster=${cluster}] Running oc adm inspect storageclasses,persistentvolumes"
+    usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster} storageclasses,persistentvolumes &
+
+    # Collect Route and Service info needed to troubleshoot direct image migration connection
+    for ns in default openshift-image-registry; do
+      echo "[cluster=${cluster}][namespace=${ns}] Running oc adm inspect route,service"
+      /usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster} -n ${ns} route,service &
+    done
+
     # Collect the migration and velero CRs
     echo "[cluster=${cluster}] Gathering MTC and Velero CRs for namespaces [${namespaces[@]}]"
     /usr/bin/gather_crs ${cluster} ${namespaces} &

--- a/collection-scripts/gather_migrated_namespaces
+++ b/collection-scripts/gather_migrated_namespaces
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Default to gathering 72h of logs unless specified as var
-logs_since="${logs_since:-72h}"
-
 unset KUBECONFIG
 for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --all-namespaces --no-headers | awk '{print $1}'); do
   clusters=()
@@ -17,7 +14,6 @@ for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --a
   echo "Will collect debug info from migclusters [${clusters[@]}]"
 
   # Find the latest migration, plan, and associated namespaces so we can gather additional info from those
-  set -x
   latest_migration=$(oc -n ${localns} get migmigration -o json | jq -r '.items|=sort_by(.metadata.creationTimestamp)' | jq -r '.items[-1].metadata.name')
   latest_migration_plan=$(oc -n ${localns} get migmigration ${latest_migration} -o jsonpath={.spec.migPlanRef.name})
   latest_migration_namespaces=$(oc -n ${localns} get migplan ${latest_migration_plan} -o json | jq -r '.spec.namespaces[]')
@@ -59,60 +55,11 @@ for localns in $(/usr/bin/oc get migrationcontrollers.migration.openshift.io --a
     else
       echo "[cluster=${cluster}] NOT FOUND within latest_migration_clusters=${latest_migration_clusters}"
     fi
-
-
-    # Collect all resources in MTC namespaces with must-gather
-    for ns in ${namespaces[@]}; do
-      echo "[cluster=${cluster}][namespace=${ns}] Running oc adm inspect"
-      /usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster} --all-namespaces ns/${ns} &
-    done
-
-    # Collect PV and StorageClass info for cluster
-    echo "[cluster=${cluster}] Running oc adm inspect storageclasses,persistentvolumes"
-    usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster} storageclasses,persistentvolumes &
-
-    # Collect Route and Service info needed to troubleshoot direct image migration connection
-    for ns in default openshift-image-registry; do
-      echo "[cluster=${cluster}][namespace=${ns}] Running oc adm inspect route,service"
-      /usr/bin/oc adm inspect --dest-dir must-gather/clusters/${cluster} -n ${ns} route,service &
-    done
-
-    # Collect the migration and velero CRs
-    echo "[cluster=${cluster}] Gathering MTC and Velero CRs for namespaces [${namespaces[@]}]"
-    /usr/bin/gather_crs ${cluster} ${namespaces} &
-
-    # Collect the logs"
-    echo "[cluster=${cluster}] Gathering logs for namespaces [${namespaces[@]}]"
-    /usr/bin/gather_logs ${cluster} ${namespaces} ${logs_since} &
   done
-
-  # Collect metrics from Prometheus
-  if [ -z "$essential_only" ]; then
-    echo "[cluster=host] Gathering prometheus metrics"
-    /usr/bin/gather_metrics &
-  else
-    echo "Essential-only must-gather was requested. Skipping prometheus metrics collection"
-  fi
-
-  # Collect memory profile data
-  if [ -z "$essential_only" ]; then
-    /usr/bin/gather_pprof ${localns} &
-  else
-    echo "Essential-only must-gather was requested. Skipping pprof memory profile gather"
-  fi
-
-  # Waits for gather_crs, gather_logs, gather_metrics running in background
+  
   echo "Waiting for background gather tasks to finish"
   wait
 done
-
-# If running essential-only must-gather, delete duplicated logs collected by oc adm inspect
-if [ -z "$essential_only" ]; then
-  echo "Full must-gather was requested. Keeping full log payload from oc adm inspect"
-else
-  echo "Essential-only must-gather was requested. Removing duplicate pod logs from oc adm inspect to reduce must-gather size"
-  find /must-gather/clusters/*/namespaces/*/pods/ -name '*.log' -delete
-fi
 
 # Tar all must-gather artifacts for faster transmission 
 echo "Tarring must-gather artifacts..."


### PR DESCRIPTION
Closes #32 

- Provides new, separate command for gathering content of namespaces from most recent migration attempt

  ```
  oc adm must-gather --image=quay.io/konveyor/must-gather:latest -- /usr/bin/gather_migrated_namespaces
   ```

- Adds gather of StorageClasses, PVs
- Adds gather of Routes, Service from `default` and `openshift-image-registry` namespaces