### PR TITLE
Get logs from our helper containers in other namespaces

### DIFF
--- a/collection-scripts/gather_logs
+++ b/collection-scripts/gather_logs
@@ -10,6 +10,8 @@ logs_since=$3
 base_path="/must-gather/migplans"
 mkdir -p ${base_path}
 
+gather_logs_helper_pods ${cluster} ${namespaces} ${logs_since} ${max_parallelism} &
+
 # Collect all Pod logs from namespaces where MTC is installed
 for ns in ${namespaces[@]}; do
 

--- a/collection-scripts/logs/gather_logs_helper_pods
+++ b/collection-scripts/logs/gather_logs_helper_pods
@@ -1,0 +1,31 @@
+#!/bin/bash
+source pwait
+
+# Cluster passed in from gather_logs
+cluster=$1
+namespaces=$2
+logs_since=$3
+max_parallelism=$4
+
+export IFS=$'\n'
+
+for ns in $(/usr/bin/oc get pods --no-headers -A -l app.kubernetes.io/part-of=openshift-migration | awk '{print $1}' | sort -u); do
+    if echo $namespaces | grep -q -w $ns; then
+        continue
+    fi
+    
+    for pod in $(/usr/bin/oc get pods --no-headers -n ${ns} -l app.kubernetes.io/part-of=openshift-migration | awk '{print $1}'); do
+        object_collection_path="/must-gather/clusters/${cluster}/namespaces/${ns}/logs/${pod}"
+        mkdir -p ${object_collection_path}
+
+        containers="--all-containers"
+
+        echo "[cluster=${cluster}][ns=${ns}][pod=${pod}] Collecting helper Pod logs..."
+        /usr/bin/oc logs ${containers} --namespace ${ns} ${pod} --since ${logs_since} &> "${object_collection_path}/current.log" &
+        echo "[cluster=${cluster}][ns=${ns}][pod=${pod}] Collecting previous helper Pod logs..."
+        /usr/bin/oc logs --previous ${containers} --namespace ${ns} ${pod} --since ${logs_since} &> "${object_collection_path}/previous.log" & 
+        pwait $max_parallelism
+    done
+done
+
+wait


### PR DESCRIPTION
We're having to access customers to manually retrieve logs for containers in the namespaces being migrated, which consumes time. It's also error prone, because the logs are not always dumped from each container (for instance both rsync and stunnel containers in the rsync pod), which requires additional back and forth.

This PR aims to prevent some of the slow down and pain.