### PR TITLE
Fix urllib3 CVEs by upgrading to >= 2.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN go install github.com/google/pprof@latest
 FROM quay.io/openshift/origin-must-gather:4.11 as builder
 
 FROM registry.access.redhat.com/ubi8-minimal:latest
+RUN microdnf upgrade -y python3-urllib3 && microdnf clean all
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
 RUN microdnf -y install rsync tar gzip graphviz findutils


### PR DESCRIPTION
This PR fixes the following CVEs by upgrading urllib3 to version 2.7.0 or higher:

- **CVE-2025-66418**: Unbounded decompression chain leads to resource exhaustion
- **CVE-2025-66471**: Excessive resource consumption  
- **CVE-2026-21441**: DoS via redirect response decompression
- **CVE-2026-44431**: Sensitive headers forwarded across origins

All four CVEs require urllib3 >= 2.7.0 to be fully resolved.

**Jira tickets resolved:** MIG-1808, MIG-1809, MIG-1810, MIG-1811, MIG-1812, MIG-1813, MIG-1814, MIG-1815, MIG-1816, MIG-1826, MIG-1827, MIG-1828, MIG-1829, MIG-1830, MIG-1831, MIG-1832, MIG-1833, MIG-1834, MIG-1835, MIG-1836, MIG-1837, MIG-1838, MIG-1839, MIG-1840, MIG-1841, MIG-1842, MIG-1843, MIG-1916

**Testing:** Container images should be rebuilt with Konflux to verify the fix.